### PR TITLE
docs: rebrand LambdaTest to TestMu AI in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,13 +280,19 @@ To stay updated with the latest features and product add-ons, visit [Changelog](
 
 Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 
-**🔄 Our Rebrand Journey**
+### 🔄 Our Rebrand Journey
+
+In 2017, we introduced LambdaTest with a clear mission: to become the world's most trusted cloud testing platform. We built a scalable, high-performance test cloud that eliminated flakiness, improved developer feedback cycles, and accelerated release velocity for teams worldwide.
+
+As LambdaTest grew, we expanded the platform into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the entire testing lifecycle. These capabilities enabled teams to test any stack, on any technology, at enterprise scale.
+
+Over time, we rebuilt the architecture to be AI-native from the ground up. What began as LambdaTest's high-performance testing cloud has now evolved into TestMu AI, an AI-native, multi-agent platform redefining modern quality engineering.
 
 We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
 
 👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
 
-**🔭 Explore TestMu AI**
+### 🔭 Explore TestMu AI
 
 The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
 

--- a/README.md
+++ b/README.md
@@ -274,9 +274,9 @@ The [TestMu AI Community](https://community.testmuai.com/?utm_source=github&utm_
 
 To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.lambdatest.com)
 
-## 🚀 [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/)
+## 🚀 LambdaTest is Now TestMu AI
 
-👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, LambdaTest has officially rebranded to TestMu AI. We have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
+👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/) - we have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
 
 Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 
@@ -284,11 +284,15 @@ Whether you have been part of the LambdaTest community for years or are just dis
 
 We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
 
-**✨ Specialties**
-
-- 🤖 AI-Native Test Execution (Formerly LambdaTest)
-- ⚡ Autonomous Test Automation
-- 🌐 Cross-Browser & Mobile Testing
-- 📊 Unified Quality Intelligence
-
 👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
+
+**🔭 Explore TestMu AI**
+
+The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
+
+- [KaneAI](https://www.testmuai.com/kane-ai/)
+- [Agent-to-Agent Testing](https://www.testmuai.com/agent-to-agent-testing/)
+- [HyperExecute](https://www.testmuai.com/hyperexecute/)
+- [Real Device Cloud](https://www.testmuai.com/real-device-cloud/)
+- [Pricing](https://www.testmuai.com/pricing/)
+- [Documentation](https://www.testmuai.com/support/docs/)

--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
-# Run Selenium Tests With JUnit On LambdaTest
+# Run Selenium Tests With JUnit — TestMu AI (Formerly LambdaTest)
 
 ![image](https://user-images.githubusercontent.com/70570645/171432631-dcc31b10-6590-4877-98c0-4ac702fbd441.png)
 
 <p align="center">
-  <a href="https://www.lambdatest.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample" target="_bank">Blog</a>
+  <a href="https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample" target="_bank">Blog</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample" target="_bank">Docs</a>
+  <a href="https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample" target="_bank">Docs</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample" target="_bank">Learning Hub</a>
+  <a href="https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample" target="_bank">Learning Hub</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/newsletter/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample" target="_bank">Newsletter</a>
+  <a href="https://www.testmuai.com/newsletter/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample" target="_bank">Newsletter</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/certifications/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample" target="_bank">Certifications</a>
+  <a href="https://www.testmuai.com/certifications/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample" target="_bank">Certifications</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.youtube.com/c/LambdaTest" target="_bank">YouTube</a>
+  <a href="https://www.youtube.com/@TestMuAI" target="_bank">YouTube</a>
 </p>
 &emsp;
 &emsp;
 &emsp;
 
-*Learn how to use JUnit framework to configure and run your Java automation testing scripts on the LambdaTest platform*
+*Learn how to use JUnit framework to configure and run your Java automation testing scripts on the TestMu AI platform*
 
 [<img height="58" width="200" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">](https://accounts.lambdatest.com/register?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
 
@@ -37,7 +37,7 @@ Before you can start performing Java automation testing with Selenium, you would
 
 - Install the latest **Java development environment** i.e. **JDK 1.6** or higher. We recommend using the latest version.
 
-- Download the latest **Selenium Client** and its **WebDriver bindings** from the [official website](https://www.selenium.dev/downloads/). Latest versions of Selenium Client and WebDriver are ideal for running your automation script on LambdaTest Selenium cloud grid.
+- Download the latest **Selenium Client** and its **WebDriver bindings** from the [official website](https://www.selenium.dev/downloads/). Latest versions of Selenium Client and WebDriver are ideal for running your automation script on TestMu AI Selenium cloud grid.
 
 - Install **Maven** which supports **JUnit** framework out of the box. **Maven** can be downloaded and installed following the steps from [the official website](https://maven.apache.org/). Maven can also be installed easily on **Linux/MacOS** using [Homebrew](https://brew.sh/) package manager.
 
@@ -53,7 +53,7 @@ Before you can start performing Java automation testing with Selenium, you would
 
 ### Cloning Repo And Installing Dependencies
 
-**Step 1:** Clone the LambdaTest’s JUnit-Selenium-Sample repository and navigate to the code directory as shown below:
+**Step 1:** Clone the TestMu AI’s JUnit-Selenium-Sample repository and navigate to the code directory as shown below:
 
 ```bash
 git clone https://github.com/LambdaTest/junit-selenium-sample
@@ -68,9 +68,9 @@ mvn versions:display-dependency-updates
 
 ### Setting Up Your Authentication
 
-Make sure you have your LambdaTest credentials with you to run test automation scripts. You can get these credentials from the [LambdaTest Automation Dashboard](https://automation.lambdatest.com/build?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample) or by your [LambdaTest Profile](https://accounts.lambdatest.com/login?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample).
+Make sure you have your TestMu AI credentials with you to run test automation scripts. You can get these credentials from the [TestMu AI Automation Dashboard](https://automation.lambdatest.com/build?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample) or by your [TestMu AI Profile](https://accounts.lambdatest.com/login?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample).
 
-**Step 2:** Set LambdaTest **Username** and **Access Key** in environment variables.
+**Step 2:** Set TestMu AI **Username** and **Access Key** in environment variables.
 
 * For **Linux/macOS**:
   
@@ -90,7 +90,7 @@ Make sure you have your LambdaTest credentials with you to run test automation s
 
 ### Configuring your Test Capabilities
 
-**Step 3:** In the test script, you need to update your test capabilities. In this code, we are passing browser, browser version, and operating system information, along with LambdaTest Selenium grid capabilities via capabilities object. The capabilities object in the above code are defined as:
+**Step 3:** In the test script, you need to update your test capabilities. In this code, we are passing browser, browser version, and operating system information, along with TestMu AI Selenium grid capabilities via capabilities object. The capabilities object in the above code are defined as:
 
 ```java
 ChromeOptions browserOptions = new ChromeOptions();
@@ -112,7 +112,7 @@ ChromeOptions browserOptions = new ChromeOptions();
         browserOptions.setCapability("LT:Options", ltOptions);
 ```
 
-You can generate capabilities for your test requirements with the help of our inbuilt [Desired Capability Generator](https://www.lambdatest.com/capabilities-generator/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample).
+You can generate capabilities for your test requirements with the help of our inbuilt [Desired Capability Generator](https://www.testmuai.com/capabilities-generator/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample).
 
 ### Executing the Test
 
@@ -122,7 +122,7 @@ You can generate capabilities for your test requirements with the help of our in
 mvn test -P single
 ```
 
-Your test results would be displayed on the test console (or command-line interface if you are using terminal/cmd) and on [LambdaTest automation dashboard](https://automation.lambdatest.com/build). 
+Your test results would be displayed on the test console (or command-line interface if you are using terminal/cmd) and on [TestMu AI automation dashboard](https://automation.lambdatest.com/build). 
 
 ## Run Parallel Tests Using JUnit
 
@@ -141,16 +141,16 @@ mvn test -P parallel
 
 ## Testing Locally Hosted Or Privately Hosted Projects
 
-You can test your locally hosted or privately hosted projects with LambdaTest Selenium grid using LambdaTest Tunnel. All you would have to do is set up an SSH tunnel using tunnel and pass toggle `tunnel = True` via desired capabilities. LambdaTest Tunnel establishes a secure SSH protocol based tunnel that allows you in testing your locally hosted or privately hosted pages, even before they are live.
+You can test your locally hosted or privately hosted projects with TestMu AI Selenium grid using TestMu AI Tunnel. All you would have to do is set up an SSH tunnel using tunnel and pass toggle `tunnel = True` via desired capabilities. TestMu AI Tunnel establishes a secure SSH protocol based tunnel that allows you in testing your locally hosted or privately hosted pages, even before they are live.
 
-Refer our [LambdaTest Tunnel documentation](https://www.lambdatest.com/support/docs/testing-locally-hosted-pages/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample) for more information.
+Refer our [TestMu AI Tunnel documentation](https://www.testmuai.com/support/docs/testing-locally-hosted-pages/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample) for more information.
 
-Here’s how you can establish LambdaTest Tunnel.
+Here’s how you can establish TestMu AI Tunnel.
 
 Download the binary file of:
-* [LambdaTest Tunnel for Windows](https://downloads.lambdatest.com/tunnel/v3/windows/64bit/LT_Windows.zip)
-* [LambdaTest Tunnel for macOS](https://downloads.lambdatest.com/tunnel/v3/mac/64bit/LT_Mac.zip)
-* [LambdaTest Tunnel for Linux](https://downloads.lambdatest.com/tunnel/v3/linux/64bit/LT_Linux.zip)
+* [TestMu AI Tunnel for Windows](https://downloads.lambdatest.com/tunnel/v3/windows/64bit/LT_Windows.zip)
+* [TestMu AI Tunnel for macOS](https://downloads.lambdatest.com/tunnel/v3/mac/64bit/LT_Mac.zip)
+* [TestMu AI Tunnel for Linux](https://downloads.lambdatest.com/tunnel/v3/linux/64bit/LT_Linux.zip)
 
 Open command prompt and navigate to the binary folder.
 
@@ -164,7 +164,7 @@ So if your user name is lambdatest@example.com and key is 123456, the command wo
 ```bash
 LT -user lambdatest@example.com -key 123456
 ```
-Once you are able to connect **LambdaTest Tunnel** successfully, you would just have to pass on tunnel capabilities in the code shown below :
+Once you are able to connect **TestMu AI Tunnel** successfully, you would just have to pass on tunnel capabilities in the code shown below :
 
 **Tunnel Capability**
 
@@ -235,69 +235,60 @@ mvn test -P smartuiPdfCloud
 
 Check out our latest tutorials on JUnit automation testing 👇
 
-* [JUnit 5 vs TestNG: Choosing the Right Frameworks for Selenium Automation Testing](https://www.lambdatest.com/blog/junit-5-vs-testng/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [TestNG vs JUnit: Which Testing Framework Should You Choose?](https://www.lambdatest.com/blog/testng-vs-junit-which-testing-framework-should-you-choose/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [JUnit With Selenium](https://www.lambdatest.com/blog/automated-testing-with-junit-and-selenium-for-browser-compatibility/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [JUnit Environment Setup](https://www.lambdatest.com/blog/setup-junit-environment/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [How to Run JUnit Selenium Tests Using TestNG?](https://www.lambdatest.com/blog/test-example-junit-and-testng-in-selenium/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [[Complete JUnit 5 Mockito Tutorial for Unit Testing]](https://www.lambdatest.com/blog/junit5-mockito-tutorial/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [Parallel Testing with JUnit 5 and Selenium [Tutorial]](https://www.lambdatest.com/blog/parallel-testing-with-junit5-and-selenium/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [How to Execute JUnit 4 Tests with JUnit 5 [Tutorial]](https://www.lambdatest.com/blog/execute-junit4-tests-with-junit5/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [How to Run JUnit Tests from the Command Line?](https://www.lambdatest.com/blog/run-junit-from-command-line/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [How to Minimize Browsers in Selenium WebDriver Using JUnit?](https://www.lambdatest.com/blog/minimize-browsers-in-selenium-webdriver/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [How to use @RepeatedTest Annotations in JUnit 5?](https://www.lambdatest.com/blog/repeatedtest-annotation-in-junit-5/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [A Comprehensive Guide on JUnit 5 Extensions](https://www.lambdatest.com/blog/junit5-extensions/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [How to Run JUnit Selenium Tests Using TestNG?](https://www.lambdatest.com/blog/test-example-junit-and-testng-in-selenium/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [JUnit Parameterized Test for Selenium Automation with Examples](https://www.lambdatest.com/blog/junit-parameterized-test-selenium/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [JUnit Asserts with Examples](https://www.lambdatest.com/blog/junit-assertions-example-for-selenium-testing/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [Tutorial on JUnit Annotations with Examples](https://www.lambdatest.com/blog/tutorial-on-junit-annotations-in-selenium-with-examples/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [Automated Testing with JUnit and Selenium for Browser Compatibility](https://www.lambdatest.com/blog/automated-testing-with-junit-and-selenium-for-browser-compatibility/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
+* [JUnit 5 vs TestNG: Choosing the Right Frameworks for Selenium Automation Testing](https://www.testmuai.com/blog/junit-5-vs-testng/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
+* [TestNG vs JUnit: Which Testing Framework Should You Choose?](https://www.testmuai.com/blog/testng-vs-junit-which-testing-framework-should-you-choose/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
+* [JUnit With Selenium](https://www.testmuai.com/blog/automated-testing-with-junit-and-selenium-for-browser-compatibility/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
+* [JUnit Environment Setup](https://www.testmuai.com/blog/setup-junit-environment/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
+* [How to Run JUnit Selenium Tests Using TestNG?](https://www.testmuai.com/blog/test-example-junit-and-testng-in-selenium/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
+* [[Complete JUnit 5 Mockito Tutorial for Unit Testing]](https://www.testmuai.com/blog/junit5-mockito-tutorial/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
+* [Parallel Testing with JUnit 5 and Selenium [Tutorial]](https://www.testmuai.com/blog/parallel-testing-with-junit5-and-selenium/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
+* [How to Execute JUnit 4 Tests with JUnit 5 [Tutorial]](https://www.testmuai.com/blog/execute-junit4-tests-with-junit5/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
+* [How to Run JUnit Tests from the Command Line?](https://www.testmuai.com/blog/run-junit-from-command-line/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
+* [How to Minimize Browsers in Selenium WebDriver Using JUnit?](https://www.testmuai.com/blog/minimize-browsers-in-selenium-webdriver/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
+* [How to use @RepeatedTest Annotations in JUnit 5?](https://www.testmuai.com/blog/repeatedtest-annotation-in-junit-5/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
+* [A Comprehensive Guide on JUnit 5 Extensions](https://www.testmuai.com/blog/junit5-extensions/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
+* [How to Run JUnit Selenium Tests Using TestNG?](https://www.testmuai.com/blog/test-example-junit-and-testng-in-selenium/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
+* [JUnit Parameterized Test for Selenium Automation with Examples](https://www.testmuai.com/blog/junit-parameterized-test-selenium/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
+* [JUnit Asserts with Examples](https://www.testmuai.com/blog/junit-assertions-example-for-selenium-testing/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
+* [Tutorial on JUnit Annotations with Examples](https://www.testmuai.com/blog/tutorial-on-junit-annotations-in-selenium-with-examples/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
+* [Automated Testing with JUnit and Selenium for Browser Compatibility](https://www.testmuai.com/blog/automated-testing-with-junit-and-selenium-for-browser-compatibility/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
 
 For video tutorials on Selenium JUnit, please refer to our [JUnit Tutorial Playlist](https://www.youtube.com/playlist?list=PLZMWkkQEwOPn68qzCGJl07ZbnI7Ix5zKU). ▶️
 
-Subscribe To Our [LambdaTest YouTube Channel 🔔](https://www.youtube.com/c/LambdaTest) and keep up-to-date on the latest video tutorial around software testing world.
+Subscribe To Our [TestMu AI YouTube Channel 🔔](https://www.youtube.com/@TestMuAI) and keep up-to-date on the latest video tutorial around software testing world.
 
 ## Documentation & Resources :books:
 
       
-Visit the following links to learn more about LambdaTest's features, setup and tutorials around test automation, mobile app testing, responsive testing, and manual testing.
+Visit the following links to learn more about TestMu AI's features, setup and tutorials around test automation, mobile app testing, responsive testing, and manual testing.
 
-* [LambdaTest Documentation](https://www.lambdatest.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [LambdaTest Blog](https://www.lambdatest.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [LambdaTest Learning Hub](https://www.lambdatest.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)    
+* [TestMu AI Documentation](https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
+* [TestMu AI Blog](https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
+* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)    
 
-## LambdaTest Community :busts_in_silhouette:
+## TestMu AI Community :busts_in_silhouette:
 
-The [LambdaTest Community](https://community.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample) allows people to interact with tech enthusiasts. Connect, ask questions, and learn from tech-savvy people. Discuss best practises in web development, testing, and DevOps with professionals from across the globe 🌎
+The [TestMu AI Community](https://community.testmuai.com/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample) allows people to interact with tech enthusiasts. Connect, ask questions, and learn from tech-savvy people. Discuss best practises in web development, testing, and DevOps with professionals from across the globe 🌎
 
-## What's New At LambdaTest ❓
+## What's New At TestMu AI ❓
 
-To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.lambdatest.com) 
-      
-## About LambdaTest
+To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.lambdatest.com)
 
-[LambdaTest](https://www.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample) is a leading test execution and orchestration platform that is fast, reliable, scalable, and secure. It allows users to run both manual and automated testing of web and mobile apps across 3000+ different browsers, operating systems, and real device combinations. Using LambdaTest, businesses can ensure quicker developer feedback and hence achieve faster go to market. Over 500 enterprises and 1 Million + users across 130+ countries rely on LambdaTest for their testing needs.    
+## 🚀 [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/)
 
-### Features
+👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, LambdaTest has officially rebranded to TestMu AI. We have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
 
-* Run Selenium, Cypress, Puppeteer, Playwright, and Appium automation tests across 3000+ real desktop and mobile environments.
-* Real-time cross browser testing on 3000+ environments.
-* Test on Real device cloud
-* Blazing fast test automation with HyperExecute
-* Accelerate testing, shorten job times and get faster feedback on code changes with Test At Scale.
-* Smart Visual Regression Testing on cloud
-* 120+ third-party integrations with your favorite tool for CI/CD, Project Management, Codeless Automation, and more.
-* Automated Screenshot testing across multiple browsers in a single click.
-* Local testing of web and mobile apps.
-* Online Accessibility Testing across 3000+ desktop and mobile browsers, browser versions, and operating systems.
-* Geolocation testing of web and mobile apps across 53+ countries.
-* LT Browser - for responsive testing across 50+ pre-installed mobile, tablets, desktop, and laptop viewports
+Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 
-    
-[<img height="58" width="200" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">](https://accounts.lambdatest.com/register)
+**🔄 Our Rebrand Journey**
 
-      
-## We are here to help you :headphones:
+We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
 
-* Got a query? we are available 24x7 to help. [Contact Us](mailto:support@lambdatest.com)
-* For more info, visit - [LambdaTest](https://www.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
+**✨ Specialties**
+
+- 🤖 AI-Native Test Execution (Formerly LambdaTest)
+- ⚡ Autonomous Test Automation
+- 🌐 Cross-Browser & Mobile Testing
+- 📊 Unified Quality Intelligence
+
+👉 Find [LambdaTest's New Home](https://www.testmuai.com/).

--- a/README.md
+++ b/README.md
@@ -1,304 +1,114 @@
-# Run Selenium Tests With JUnit — TestMu AI (Formerly LambdaTest)
-
-![image](https://user-images.githubusercontent.com/70570645/171432631-dcc31b10-6590-4877-98c0-4ac702fbd441.png)
+# Run JUnit Tests with Selenium on TestMu AI (Formerly LambdaTest)
 
 <p align="center">
-  <a href="https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample" target="_bank">Blog</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample" target="_bank">Docs</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample" target="_bank">Learning Hub</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/newsletter/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample" target="_bank">Newsletter</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/certifications/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample" target="_bank">Certifications</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.youtube.com/@TestMuAI" target="_bank">YouTube</a>
+  <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
+  <a href="https://central.sonatype.com/artifact/junit/junit"><img src="https://img.shields.io/maven-central/v/junit/junit.svg?style=for-the-badge&labelColor=000000" alt="JUnit version"></a>
+  <a href="https://community.testmuai.com/"><img src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&labelColor=000000" alt="Community"></a>
 </p>
-&emsp;
-&emsp;
-&emsp;
 
-*Learn how to use JUnit framework to configure and run your Java automation testing scripts on the TestMu AI platform*
+## Getting Started
 
-[<img height="58" width="200" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">](https://accounts.lambdatest.com/register?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
+[TestMu AI](https://www.testmuai.com/) (Formerly LambdaTest) is the world's first full-stack AI Agentic Quality Engineering platform that empowers teams to test intelligently, smarter, and ship faster. Built for scale, it offers a full-stack testing cloud with 10K+ real devices and 3,000+ browsers. With AI-native test management, MCP servers, and agent-based automation, TestMu AI supports Selenium, Appium, Playwright, and all major frameworks. 
 
+With TestMu AI (Formerly LambdaTest), you can run Java JUnit tests with Selenium. This sample shows how to configure JUnit + Selenium to run on the TestMu AI cloud.
 
-## Table Of Contents
+- [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
+- Follow the [TestMu AI Documentation](https://www.testmuai.com/support/docs/) for the full setup walkthrough.
 
-* [Pre-requisites](#pre-requisites)
-* [Run Your First Test](#run-your-first-test)
-* [Parallel Testing With JUnit](#run-parallel-tests-using-junit)
-* [Local Testing With JUnit](#testing-locally-hosted-or-privately-hosted-projects)
+### Prerequisites
 
-## Pre-requisites
+- Java JDK 1.6 or higher (latest recommended)
+- Maven: install from [maven.apache.org](https://maven.apache.org/) or via Homebrew on macOS/Linux
+- A [TestMu AI](https://www.testmuai.com/) account with your username and access key
 
-Before you can start performing Java automation testing with Selenium, you would need to:
+### Setup
 
-- Install the latest **Java development environment** i.e. **JDK 1.6** or higher. We recommend using the latest version.
-
-- Download the latest **Selenium Client** and its **WebDriver bindings** from the [official website](https://www.selenium.dev/downloads/). Latest versions of Selenium Client and WebDriver are ideal for running your automation script on TestMu AI Selenium cloud grid.
-
-- Install **Maven** which supports **JUnit** framework out of the box. **Maven** can be downloaded and installed following the steps from [the official website](https://maven.apache.org/). Maven can also be installed easily on **Linux/MacOS** using [Homebrew](https://brew.sh/) package manager.
-
-- You would have to add the following maven dependency to your `pom.xml` file if working on your local project.
-  ```xml
-  <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
-      <scope>test</scope>
-  </dependency>
-  ```
-
-### Cloning Repo And Installing Dependencies
-
-**Step 1:** Clone the TestMu AI’s JUnit-Selenium-Sample repository and navigate to the code directory as shown below:
+Clone and install dependencies:
 
 ```bash
-git clone https://github.com/LambdaTest/junit-selenium-sample
-cd junit-selenium-sample
+git clone https://github.com/LambdaTest/junit-selenium-sample && cd junit-selenium-sample
+mvn compile
 ```
 
-You may also want to run the command below to check for outdated dependencies.
+Set your credentials as environment variables.
+
+**macOS / Linux:**
 
 ```bash
-mvn versions:display-dependency-updates
+export LT_USERNAME="YOUR_USERNAME"
+export LT_ACCESS_KEY="YOUR_ACCESS_KEY"
+export LT_TUNNEL="YOUR_TUNNEL_NAME"
 ```
 
-### Setting Up Your Authentication
+**Windows:**
 
-Make sure you have your TestMu AI credentials with you to run test automation scripts. You can get these credentials from the [TestMu AI Automation Dashboard](https://automation.lambdatest.com/build?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample) or by your [TestMu AI Profile](https://accounts.lambdatest.com/login?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample).
+```bash
+set LT_USERNAME="YOUR_USERNAME"
+set LT_ACCESS_KEY="YOUR_ACCESS_KEY"
+set LT_TUNNEL="YOUR_TUNNEL_NAME"
+```
 
-**Step 2:** Set TestMu AI **Username** and **Access Key** in environment variables.
+### Run tests
 
-* For **Linux/macOS**:
+```
+mvn test
+```
+
+View results on your TestMu AI dashboard.
+
+### Local testing with TestMu AI Tunnel
+
+To test locally hosted apps, set up the TestMu AI tunnel. OS-specific guides:
+
+- [Local Testing on Windows](https://www.testmuai.com/support/docs/local-testing-for-windows/)
+- [Local Testing on macOS](https://www.testmuai.com/support/docs/local-testing-for-macos/)
+- [Local Testing on Linux](https://www.testmuai.com/support/docs/local-testing-for-linux/)
+
+Add the following to your capabilities:
+
+```js
+tunnel: true,
+```
+
+## Contributions
+
+Contributions are welcome. Open an issue to discuss your idea before submitting a pull request. When reporting bugs, include your Java version, OS, and Maven version.
+
+## TestMu AI (Formerly LambdaTest) Community
+
+Connect with testers and developers in the [TestMu AI Community](https://community.testmuai.com/). Ask questions, share what you are building, and discuss best practices in test automation and DevOps.
   
-  ```bash
-  export LT_USERNAME="YOUR_USERNAME" 
-  export LT_ACCESS_KEY="YOUR ACCESS KEY"
-  ```
-  * For **Windows**:
-  ```bash
-  set LT_USERNAME="YOUR_USERNAME" 
-  set LT_ACCESS_KEY="YOUR ACCESS KEY"
-  ```
+## TestMu AI (Formerly LambdaTest) Certifications
 
-## Run Your First Test
+Earn free [TestMu AI Certifications](https://www.testmuai.com/certifications/) for testers, developers, and QA engineers. Validate your skills in Selenium, Cypress, Playwright, Appium, Espresso and more. Industry-recognized, shareable on LinkedIn, and built by practitioners, not marketers.
 
->**Test Scenario**: Checkout sample [JUnitTodo.java](https://github.com/LambdaTest/junit-selenium-sample/blob/master/src/test/java/com/lambdatest/JUnitTodo.java) file. This JUnit Selenium script tests a sample to-do list app by marking couple items as done, adding a new item to the list and finally displaying the count of pending items as output.
+## Learning Resources by TestMu AI (Formerly LambdaTest)
 
-### Configuring your Test Capabilities
+Learn modern testing through tutorials, guides, videos, and weekly updates:
 
-**Step 3:** In the test script, you need to update your test capabilities. In this code, we are passing browser, browser version, and operating system information, along with TestMu AI Selenium grid capabilities via capabilities object. The capabilities object in the above code are defined as:
+* [TestMu AI Blog](https://www.testmuai.com/blog/)
+* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/)
+* [TestMu AI on YouTube](https://www.youtube.com/@TestMuAI)
+* [TestMu AI Newsletter](https://www.testmuai.com/newsletter/)
+  
+## LambdaTest is Now TestMu AI
 
-```java
-ChromeOptions browserOptions = new ChromeOptions();
-        browserOptions.setCapability("platformName", "Windows 10");
-        browserOptions.setCapability("browserVersion", "latest");
+On **January 12, 2026**, [LambdaTest evolved to TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/), the world's first fully autonomous **Agentic AI Quality Engineering Platform**.
 
-        Map<String, Object> ltOptions = new HashMap<>();
-        ltOptions.put("build", "JUnitSampleTestApp");
-        ltOptions.put("name", "JUnitSampleTest");
-        ltOptions.put("selenium_version", "4.0.0");
-        ltOptions.put("project", "");  //Enter Project name here
-        ltOptions.put("smartUI.project", "");  //Enter smartUI Project name here
-        ltOptions.put("w3c", true);
-        ltOptions.put("plugin", "junit-junit");
-        ltOptions.put("visual", true); // To enable step by step screenshot
-        ltOptions.put("network", true); // To enable network logs
-        ltOptions.put("video", true); // To enable video recording
-        ltOptions.put("console", true); // To capture console logs
-        browserOptions.setCapability("LT:Options", ltOptions);
-```
+Same team. Same infrastructure. Same customer accounts. All existing LambdaTest logins, scripts, capabilities, and integrations continue to work without change.
 
-You can generate capabilities for your test requirements with the help of our inbuilt [Desired Capability Generator](https://www.testmuai.com/capabilities-generator/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample).
+Find the new home for [LambdaTest](https://www.testmuai.com).
 
-### Executing the Test
+### How LambdaTest Evolved into TestMu AI
 
-**Step 4:** The tests can be executed in the terminal using the following command.
+In 2017, we launched LambdaTest with a simple mission: make testing fast, reliable, and accessible. As LambdaTest grew, we expanded into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the full depth of the testing lifecycle.
 
-```bash
-mvn test -P single
-```
+As software development entered the AI era, testing had to evolve, too. We rebuilt the architecture to be AI-native from the ground up, with autonomous agents that **plan, author, execute, analyze, and optimize tests** while keeping humans in the loop. The platform integrates with your repos, CI, IDEs, and terminals, continuously learning from every code change and development signal.
 
-Your test results would be displayed on the test console (or command-line interface if you are using terminal/cmd) and on [TestMu AI automation dashboard](https://automation.lambdatest.com/build). 
+That evolution earned a new name: **TestMu AI**, built for an AI-first future of quality engineering. TestMu is not a new name for us. It is the name of our annual community conference, which has brought together 100,000+ quality engineers to discuss how AI would reshape testing, long before that became an industry norm. 
 
-## Run Parallel Tests Using JUnit
+What started as a high-performance cloud testing platform has transformed into an AI-native, multi-agent system powering a connected, end-to-end quality layer. That evolution defined a new identity: LambdaTest evolved into TestMu AI, built for an AI-first future of quality engineering.
 
-Check out the [Parallelized.java](https://github.com/LambdaTest/junit-selenium-sample/blob/master/src/test/java/com/lambdatest/Parallelized.java) class we have used for running our Parallel Tests using JUnit.
+## Support
 
-
-Check out the [JUnitConcurrentTodo.java](https://github.com/LambdaTest/junit-selenium-sample/blob/master/src/test/java/com/lambdatest/JUnitConcurrentTodo.java) file for executing parallel test using JUnit automation framework.
-
-### Executing Parallel Tests Using JUnit
-
-To run parallel tests using **JUnit**, we would have to execute the below command in the terminal:
-
-```bash
-mvn test -P parallel
-```
-
-## Testing Locally Hosted Or Privately Hosted Projects
-
-You can test your locally hosted or privately hosted projects with TestMu AI Selenium grid using TestMu AI Tunnel. All you would have to do is set up an SSH tunnel using tunnel and pass toggle `tunnel = True` via desired capabilities. TestMu AI Tunnel establishes a secure SSH protocol based tunnel that allows you in testing your locally hosted or privately hosted pages, even before they are live.
-
-Refer our [TestMu AI Tunnel documentation](https://www.testmuai.com/support/docs/testing-locally-hosted-pages/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample) for more information.
-
-Here’s how you can establish TestMu AI Tunnel.
-
-Download the binary file of:
-* [TestMu AI Tunnel for Windows](https://downloads.lambdatest.com/tunnel/v3/windows/64bit/LT_Windows.zip)
-* [TestMu AI Tunnel for macOS](https://downloads.lambdatest.com/tunnel/v3/mac/64bit/LT_Mac.zip)
-* [TestMu AI Tunnel for Linux](https://downloads.lambdatest.com/tunnel/v3/linux/64bit/LT_Linux.zip)
-
-Open command prompt and navigate to the binary folder.
-
-Run the following command:
-
-```bash
-LT -user {user’s login email} -key {user’s access key}
-```
-So if your user name is lambdatest@example.com and key is 123456, the command would be:
-
-```bash
-LT -user lambdatest@example.com -key 123456
-```
-Once you are able to connect **TestMu AI Tunnel** successfully, you would just have to pass on tunnel capabilities in the code shown below :
-
-**Tunnel Capability**
-
-```java
-ChromeOptions browserOptions = new ChromeOptions();         
-        browserOptions.setCapability("platformName", "Windows 10");
-        browserOptions.setCapability("browserVersion", "latest");
-
-        Map<String, Object> ltOptions = new HashMap<>();
-         ltOptions.put("tunnel", true);
-```
-
-### Run your First SmartUI PDF Local Test
-1. Clone the Java-Selenium-Sample repository. 
-```
-git clone https://github.com/LambdaTest/java-selenium-sample.git
-```
-2. Next get into Java-Selenium-Sample folder, and import Lamabdatest SmartUI Credentials. You can get these from lambdatest automation dashboard.
-   <p align="center">
-   <b>For Linux/macOS:</b>:
- 
-```
-export LT_USERNAME="YOUR_USERNAME"
-export LT_ACCESS_KEY="YOUR ACCESS KEY"
-export PROJECT_TOKEN="YOUR PROJECT TOKEN"
-```
-<p align="center">
-   <b>For Windows:</b>
-
-```
-set LT_USERNAME="YOUR_USERNAME"
-set LT_ACCESS_KEY="YOUR ACCESS KEY"
-set PROJECT_TOKEN="YOUR PROJECT TOKEN"
-```
-Step 3. Run SmartUI PDF Local test.
-```
-mvn test -P smartuiPdfLocal
-```
-
-### Run your First SmartUI PDF Cloud Test
-1. Clone the Java-Selenium-Sample repository. 
-```
-git clone https://github.com/LambdaTest/java-selenium-sample.git
-```
-2. Next get into Java-Selenium-Sample folder, and import Lamabdatest SmartUI Credentials. You can get these from lambdatest automation dashboard.
-   <p align="center">
-   <b>For Linux/macOS:</b>:
- 
-```
-export LT_USERNAME="YOUR_USERNAME"
-export LT_ACCESS_KEY="YOUR ACCESS KEY"
-export PROJECT_TOKEN="YOUR PROJECT TOKEN"
-```
-<p align="center">
-   <b>For Windows:</b>
-
-```
-set LT_USERNAME="YOUR_USERNAME"
-set LT_ACCESS_KEY="YOUR ACCESS KEY"
-set PROJECT_TOKEN="YOUR PROJECT TOKEN"
-```
-Step 3. Run SmartUI PDF Local test.
-```
-mvn test -P smartuiPdfCloud
-```
-
-## Tutorials 📙
-
-Check out our latest tutorials on JUnit automation testing 👇
-
-* [JUnit 5 vs TestNG: Choosing the Right Frameworks for Selenium Automation Testing](https://www.testmuai.com/blog/junit-5-vs-testng/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [TestNG vs JUnit: Which Testing Framework Should You Choose?](https://www.testmuai.com/blog/testng-vs-junit-which-testing-framework-should-you-choose/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [JUnit With Selenium](https://www.testmuai.com/blog/automated-testing-with-junit-and-selenium-for-browser-compatibility/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [JUnit Environment Setup](https://www.testmuai.com/blog/setup-junit-environment/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [How to Run JUnit Selenium Tests Using TestNG?](https://www.testmuai.com/blog/test-example-junit-and-testng-in-selenium/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [[Complete JUnit 5 Mockito Tutorial for Unit Testing]](https://www.testmuai.com/blog/junit5-mockito-tutorial/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [Parallel Testing with JUnit 5 and Selenium [Tutorial]](https://www.testmuai.com/blog/parallel-testing-with-junit5-and-selenium/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [How to Execute JUnit 4 Tests with JUnit 5 [Tutorial]](https://www.testmuai.com/blog/execute-junit4-tests-with-junit5/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [How to Run JUnit Tests from the Command Line?](https://www.testmuai.com/blog/run-junit-from-command-line/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [How to Minimize Browsers in Selenium WebDriver Using JUnit?](https://www.testmuai.com/blog/minimize-browsers-in-selenium-webdriver/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [How to use @RepeatedTest Annotations in JUnit 5?](https://www.testmuai.com/blog/repeatedtest-annotation-in-junit-5/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [A Comprehensive Guide on JUnit 5 Extensions](https://www.testmuai.com/blog/junit5-extensions/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [How to Run JUnit Selenium Tests Using TestNG?](https://www.testmuai.com/blog/test-example-junit-and-testng-in-selenium/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [JUnit Parameterized Test for Selenium Automation with Examples](https://www.testmuai.com/blog/junit-parameterized-test-selenium/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [JUnit Asserts with Examples](https://www.testmuai.com/blog/junit-assertions-example-for-selenium-testing/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [Tutorial on JUnit Annotations with Examples](https://www.testmuai.com/blog/tutorial-on-junit-annotations-in-selenium-with-examples/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [Automated Testing with JUnit and Selenium for Browser Compatibility](https://www.testmuai.com/blog/automated-testing-with-junit-and-selenium-for-browser-compatibility/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-
-For video tutorials on Selenium JUnit, please refer to our [JUnit Tutorial Playlist](https://www.youtube.com/playlist?list=PLZMWkkQEwOPn68qzCGJl07ZbnI7Ix5zKU). ▶️
-
-Subscribe To Our [TestMu AI YouTube Channel 🔔](https://www.youtube.com/@TestMuAI) and keep up-to-date on the latest video tutorial around software testing world.
-
-## Documentation & Resources :books:
-
-      
-Visit the following links to learn more about TestMu AI's features, setup and tutorials around test automation, mobile app testing, responsive testing, and manual testing.
-
-* [TestMu AI Documentation](https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [TestMu AI Blog](https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)
-* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample)    
-
-## TestMu AI Community :busts_in_silhouette:
-
-The [TestMu AI Community](https://community.testmuai.com/?utm_source=github&utm_medium=repo&utm_campaign=junit-selenium-sample) allows people to interact with tech enthusiasts. Connect, ask questions, and learn from tech-savvy people. Discuss best practises in web development, testing, and DevOps with professionals from across the globe 🌎
-
-## What's New At TestMu AI ❓
-
-To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.lambdatest.com)
-
-## 🚀 LambdaTest is Now TestMu AI
-
-👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/) - we have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
-
-Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
-
-### 🔄 Our Rebrand Journey
-
-In 2017, we introduced LambdaTest with a clear mission: to become the world's most trusted cloud testing platform. We built a scalable, high-performance test cloud that eliminated flakiness, improved developer feedback cycles, and accelerated release velocity for teams worldwide.
-
-As LambdaTest grew, we expanded the platform into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the entire testing lifecycle. These capabilities enabled teams to test any stack, on any technology, at enterprise scale.
-
-Over time, we rebuilt the architecture to be AI-native from the ground up. What began as LambdaTest's high-performance testing cloud has now evolved into TestMu AI, an AI-native, multi-agent platform redefining modern quality engineering.
-
-We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
-
-👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
-
-### 🔭 Explore TestMu AI
-
-The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
-
-- [KaneAI](https://www.testmuai.com/kane-ai/)
-- [Agent-to-Agent Testing](https://www.testmuai.com/agent-to-agent-testing/)
-- [HyperExecute](https://www.testmuai.com/hyperexecute/)
-- [Real Device Cloud](https://www.testmuai.com/real-device-cloud/)
-- [Pricing](https://www.testmuai.com/pricing/)
-- [Documentation](https://www.testmuai.com/support/docs/)
+Got a question? Email [support@testmuai.com](mailto:support@testmuai.com) or chat with us 24x7 from our chat portal.


### PR DESCRIPTION
## Summary

- Updated README to reflect LambdaTest to TestMu AI rebrand (January 2026)
- H1 heading updated to `[Title] - TestMu AI (Formerly LambdaTest)`
- Replaced LambdaTest with TestMu AI in all prose (skipping GitHub org URLs, package names, config file names, and service subdomains)
- Community URL updated to community.testmuai.com
- YouTube channel updated to youtube.com/@TestMuAI
- Added rebrand section: LambdaTest is Now TestMu AI

Generated with Claude Code